### PR TITLE
Fix: Improve Login and Sign-Up Page UI Design

### DIFF
--- a/public/formstyle.css
+++ b/public/formstyle.css
@@ -65,8 +65,9 @@ body {
 .input-box i {
     font-size: 22px;
     position: absolute;
-    top: 35px;
+    top: 40px;
     right: 12px;
+    cursor: pointer; 
     color: #595b5e;
 }
 
@@ -77,7 +78,7 @@ body {
     margin: 7px 0;
     outline: none;
     font-weight: 500;
-    padding: 0 10px;
+    padding: 0 40px 0 10px;    
     font-size: 17px;
     background: transparent;
     transition: all .3s ease-in-out;
@@ -95,6 +96,7 @@ body {
     margin-top: 20px;
     background: var(--primary-color);
     border: none;
+    border-radius: 10px;
     color: #fff;
     cursor: pointer;
     transition: all .3s ease-in-out;

--- a/views/auth.ejs
+++ b/views/auth.ejs
@@ -16,11 +16,9 @@
             </div>
             <% if (errors && errors.length > 0) { %>
                 <div class="alert alert-danger">
-                    <ul>
-                        <% errors.forEach(function(error) { %>
-                            <li><%= error.msg %></li>
-                        <% }); %>
-                    </ul>
+                    <% errors.forEach(function(error) { %>
+                        <div class="error-message"><i class="bx bx-error"></i> <%= error.msg %></div>
+                    <% }); %>
                 </div>
             <% } %>
             <form action="/<%= action %>" method="post" id="authForm">
@@ -38,12 +36,12 @@
                     <div class="input-box">
                         <label for="password">Password</label>
                         <input type="password" class="input-field" id="password" name="password" placeholder="Enter Password" required>
-                        <i class="bx bx-lock"></i>
+                        <i class="bx bx-show" data-target="password" onclick="togglePasswordVisibility(this)"></i>
                     </div>
                     <div class="input-box">
                         <label for="confirmPassword">Confirm Password</label>
                         <input type="password" class="input-field" id="confirmPassword" name="confirmPassword" placeholder="Confirm Password" required>
-                        <i class="bx bx-lock"></i>
+                        <i class="bx bx-show" data-target="confirmPassword" onclick="togglePasswordVisibility(this)"></i>
                     </div>
                 <% } else { %>
                     <div class="input-box">
@@ -54,11 +52,11 @@
                     <div class="input-box">
                         <label for="password">Password</label>
                         <input type="password" class="input-field" id="password" name="password" placeholder="Enter Password" required>
-                        <i class="bx bx-lock"></i>
+                        <i class="bx bx-show" data-target="password" onclick="togglePasswordVisibility(this)"></i>
                     </div>
                 <% } %>
                 <div class="input-box">
-                    <input type="submit" class="input-submit" value="<%= action === 'login' ? 'SIGN IN' : 'SIGN UP' %>">
+                    <input type="submit" class="input-submit" value="<%= action === 'login' ? 'LOGIN' : 'SIGN UP' %>">
                 </div>
             </form>
             <div class="bottom">
@@ -67,12 +65,31 @@
                         <%= action === 'login' ? 'Sign Up' : 'Log in' %>
                     </a>
                 </span>
-                <span><a href="#">Forgot Password?</a></span>
-            </div>
+                <% if (action === 'login') { %>
+                    <span><a href="#">Forgot Password?</a></span>
+                <% } %>
+                </div>
         </div>
         <div class="wrapper"></div>
     </div>
 
     <%- include('partials/bottom_nav') %>
+    <script>
+        function togglePasswordVisibility(icon) {
+            const targetId = icon.getAttribute('data-target');
+            const passwordInput = document.getElementById(targetId);
+    
+            // Toggle between 'password' and 'text' type
+            if (passwordInput.type === 'password') {
+                passwordInput.type = 'text';
+                icon.classList.remove('bx-show');
+                icon.classList.add('bx-hide');
+            } else {
+                passwordInput.type = 'password';
+                icon.classList.remove('bx-hide');
+                icon.classList.add('bx-show');
+            }
+        }
+    </script>    
 </body>
 </html>


### PR DESCRIPTION
**Overview:**
This PR introduces multiple UI and functionality improvements across the authentication page fixing issue #23 . The changes include better error handling, a password toggle feature, and conditional UI rendering based on the page's context (login vs. signup).

---

### Changes Made:

1. **Improved Error Message Display:**
   - Replaced the bulleted list for error messages with a cleaner, more concise format.
   - The error messages are now shown in a single paragraph for better readability.

2. **Show/Hide Password Feature:**
   - Added a toggle feature for password input fields to allow users to switch between showing and hiding the password.
   - The eye icon toggles between "bx-show" and "bx-hide" when clicked, for better UX.

3. **Hide "Forgot Password?" Link on Signup Page:**
   - The "Forgot Password?" link is now hidden on the signup page to avoid confusion, as it's only relevant for the login page.

4. **Centered Icons in Input Fields:**
   - Adjusted the positioning of icons (like the show/hide icon) to ensure they are vertically aligned within the input fields.

@swarooppatilx i have made suggested changes kindly check and merge the pr, thank you

---

![image](https://github.com/user-attachments/assets/b391ec08-7527-4e55-9d45-cc1058cc6388)
