### PR TITLE
Fix code scanning alert no. 16: Database query built from user-controlled sources

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,8 +148,8 @@ app.get('/auth', (req, res) => {
 
 // Handle login form submission
 app.post('/login', [
-  body('username').notEmpty().withMessage('Username is required'),
-  body('password').notEmpty().withMessage('Password is required')
+  body('username').isString().notEmpty().withMessage('Username is required'),
+  body('password').isString().notEmpty().withMessage('Password is required')
 ], async (req, res) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
@@ -158,7 +158,7 @@ app.post('/login', [
 
   const { username, password } = req.body;
   try {
-    const user = await User.findOne({ username });
+    const user = await User.findOne({ username: { $eq: username } });
     if (user && await bcrypt.compare(password, user.password)) {
       req.session.user = user;
       res.redirect('/');


### PR DESCRIPTION
Fixes [https://github.com/swarooppatilx/scruter/security/code-scanning/16](https://github.com/swarooppatilx/scruter/security/code-scanning/16)

To fix the problem, we need to ensure that the `username` field is sanitized and validated before being used in the MongoDB query. We can use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. Additionally, we can add validation to ensure that `username` is a string.

- Add validation for the `username` field to ensure it is a non-empty string.
- Use the `$eq` operator in the MongoDB query to prevent NoSQL injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
