### PR TITLE
Fix code scanning alert no. 49: Uncontrolled data used in path expression

### DIFF
--- a/app.js
+++ b/app.js
@@ -548,6 +548,12 @@ app.post(
     if (!['food', 'house', 'market'].includes(type))
       return res.status(400).render('400');
 
+    // Validate id parameter
+    const idRegex = /^[a-zA-Z0-9]+$/;
+    if (!idRegex.test(id)) {
+      return res.status(400).render('400');
+    }
+
     const errors = validationResult(req);
     if (!errors.isEmpty())
       return res.status(400).render(`/edit/${type}/${id}`, {


### PR DESCRIPTION
Fixes [https://github.com/swarooppatilx/scruter/security/code-scanning/49](https://github.com/swarooppatilx/scruter/security/code-scanning/49)

To fix the problem, we need to ensure that the `id` parameter is validated before it is used in the path expression. One way to do this is to use a regular expression to ensure that the `id` only contains valid characters (e.g., alphanumeric characters). This will prevent any malicious input from being used in the path.

We will add a validation step before the path is used in the `render` method. Specifically, we will use a regular expression to check that the `id` only contains alphanumeric characters. If the `id` is invalid, we will return a 400 status code and render an error page.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
