### PR TITLE
 issues with dark mode appearance of quick links in footer

### DIFF
--- a/views/contact.ejs
+++ b/views/contact.ejs
@@ -145,6 +145,89 @@
                 display: none;
             }
         }
+        /* Dark Mode Styles */
+body.dark-mode {
+    background-color: #121212; /* Darker background for the body */
+    color: #e0e0e0;
+}
+
+.dark-mode .main-content {
+    background-color: #1e1e1e;
+    color: #f5f5f5;
+    box-shadow: 0 4px 15px rgba(255, 255, 255, 0.1);
+}
+
+.dark-mode .title-section h1 {
+    color: #a78bfa;
+}
+
+.dark-mode .title-section p {
+    color: #b0b0b0;
+}
+
+.dark-mode section h2 {
+    color: #ffffff;
+    border-left: 4px solid #a78bfa;
+}
+
+.dark-mode section h2 i {
+    color: #a78bfa;
+}
+
+.dark-mode .contact-form label {
+    color: #e0e0e0;
+}
+
+.dark-mode .contact-form input,
+.dark-mode .contact-form textarea {
+    background-color: #333333;
+    color: #f5f5f5;
+    border: 1px solid #444;
+}
+
+.dark-mode .contact-form button {
+    background-color: #a78bfa;
+    color: #1c1c1c;
+    border: none;
+    padding: 8px 16px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.dark-mode .contact-form button:hover {
+    background-color: #c0a3ff;
+}
+
+.dark-mode .sidebar {
+    background: linear-gradient(to bottom, #2c2c2c, #3a3a3a); /* Dark gray gradient for sidebar */
+    color: #f5f5f5;
+}
+
+.dark-mode .sidebar ul li a {
+    color: #e0e0e0;
+}
+
+.dark-mode .sidebar ul li a:hover {
+    color: #a78bfa;
+}
+
+.dark-mode a {
+    color: #a78bfa;
+    text-decoration: underline;
+}
+
+.dark-mode a:hover {
+    color: #c0a3ff;
+}
+
+.dark-mode ul {
+    color: #e0e0e0;
+}
+
+.dark-mode #progress-bar {
+    background-color: #a78bfa;
+}
+
     </style>
 </head>
 

--- a/views/help.ejs
+++ b/views/help.ejs
@@ -110,6 +110,79 @@
                 display: none;
             }
         }
+        /* Dark Mode Styles */
+body.dark-mode {
+    background-color: #121212;
+    color: #e0e0e0;
+}
+
+.dark-mode .main-content {
+    background-color: #1e1e1e;
+    color: #f5f5f5;
+    box-shadow: 0 4px 15px rgba(255, 255, 255, 0.1);
+}
+
+.dark-mode .title-section h1 {
+    color: #bb86fc;
+}
+
+.dark-mode .title-section p {
+    color: #a8a8a8;
+}
+
+.dark-mode section h2 {
+    color: #ffffff;
+    border-left: 4px solid #bb86fc;
+}
+
+.dark-mode section h2 i {
+    color: #bb86fc;
+}
+
+.dark-mode .sidebar {
+    background: linear-gradient(to bottom, #333333, #444444);
+    color: #f5f5f5;
+}
+
+.dark-mode .sidebar ul li a {
+    color: #e0e0e0;
+}
+
+.dark-mode .sidebar ul li a:hover {
+    color: #bb86fc;
+}
+
+.dark-mode .faq-question {
+    color: #e0e0e0;
+}
+
+.dark-mode .faq-answer {
+    color: #c7c7c7;
+}
+
+.dark-mode a {
+    color: #bb86fc;
+    text-decoration: underline;
+}
+
+.dark-mode a:hover {
+    color: #d0a9ff;
+}
+
+.dark-mode .cta-button {
+    background-color: #bb86fc;
+    color: #121212;
+    border: none;
+    padding: 8px 16px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.dark-mode .cta-button:hover {
+    background-color: #d0a9ff;
+    color: #121212;
+}
+
     </style>
 </head>
 

--- a/views/support.ejs
+++ b/views/support.ejs
@@ -110,6 +110,87 @@
                 display: none;
             }
         }
+        body.dark-mode {
+        background-color: #121212; /* Darker background for the body */
+        color: #e0e0e0;
+    }
+
+    .dark-mode .main-content {
+        background-color: #1e1e1e; 
+        color: #f5f5f5;
+        box-shadow: 0 4px 15px rgba(255, 255, 255, 0.1);
+    }
+
+    .dark-mode .title-section h1 {
+        color: #a78bfa; /* Light purple for main title */
+    }
+
+    .dark-mode .title-section p {
+        color: #b0b0b0; /* Gray for paragraphs */
+    }
+
+    .dark-mode section h2 {
+        color: #ffffff; /* White for section headings */
+        border-left: 4px solid #a78bfa; /* Light purple border */
+    }
+
+    .dark-mode section h2 i {
+        color: #a78bfa; /* Light purple for icons */
+    }
+
+    .dark-mode .contact-form label {
+        color: #e0e0e0; /* Light color for form labels */
+    }
+
+    .dark-mode .contact-form input,
+    .dark-mode .contact-form textarea {
+        background-color: #333333; /* Dark background for input fields */
+        color: #f5f5f5; /* Light text for input fields */
+        border: 1px solid #444; /* Dark border for input fields */
+    }
+
+    .dark-mode .contact-form button {
+        background-color: #a78bfa; /* Light purple for buttons */
+        color: #1c1c1c; /* Dark text color on buttons */
+        border: none;
+        padding: 8px 16px;
+        font-weight: bold;
+        cursor: pointer;
+    }
+
+    .dark-mode .contact-form button:hover {
+        background-color: #c0a3ff; /* Lighter purple on button hover */
+    }
+
+    .dark-mode .sidebar {
+        background: linear-gradient(to bottom, #2c2c2c, #3a3a3a); /* Dark gray gradient for sidebar */
+        color: #f5f5f5; /* Light text color for sidebar */
+    }
+
+    .dark-mode .sidebar ul li a {
+        color: #e0e0e0; /* Light color for sidebar links */
+    }
+
+    .dark-mode .sidebar ul li a:hover {
+        color: #a78bfa; /* Light purple hover color for sidebar links */
+    }
+
+    .dark-mode a {
+        color: #a78bfa; /* Light purple for links */
+        text-decoration: underline; /* Underline for links */
+    }
+
+    .dark-mode a:hover {
+        color: #c0a3ff; /* Lighter purple on link hover */
+    }
+
+    .dark-mode ul {
+        color: #e0e0e0; /* Light color for list items */
+    }
+
+    .dark-mode #progress-bar {
+        background-color: #a78bfa; /* Light purple for progress bar */
+    }
     </style>
 </head>
 


### PR DESCRIPTION
## What does this PR do?

The text is now visible across multiple pages in dark mode of links given in footer. I have fixed this bug

Fixes #418

<!-- Please provide a Video and ScreenShots for visual changes to speed up reviews -->
![image](https://github.com/user-attachments/assets/450adb64-ef0b-4d41-af49-0ce629a4be65)
![image](https://github.com/user-attachments/assets/65a625da-2c58-467f-be47-e6b7452a4a78)
![image](https://github.com/user-attachments/assets/31010ca8-a214-4d96-b451-a250625f6f6c)



## Type of change

<!-- Please delete bullets that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
## How should this be tested?

- [x] Test A
- [x] Test B

## Mandatory Tasks

- [x] Make sure you have self-reviewed the code. A decent size PR without self-review might be rejected.
