### PR TITLE
Autofix: [BUG] fix incorrect link in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Contributions are welcome! Follow these steps to contribute:
 - **Submit a pull request**  
   Go to the original repository and click on the "Pull Request" button to submit your changes.
 
-For detailed guidelines on how to contribute to this project, please refer to the [Contributing.md](Contributing.md) file.
+For detailed guidelines on how to contribute to this project, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 ---
 


### PR DESCRIPTION
Updated the link to CONTRIBUTING.md in the README.md file to correctly point to the file. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    