### PR TITLE
fixed scroll to the top

### DIFF
--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -194,16 +194,24 @@ html {
 </button>
 <script>
   // Show the scroll-to-top button when scrolled down
-  window.onscroll = function() { toggleScrollTopButton() };
+  function toggleScrollButton() {
+                var scrollButton = document.getElementById('scrollTopButton');
+                var scrollThreshold = 200;  // Threshold in pixels to show button
 
-  function toggleScrollTopButton() {
-    const button = document.getElementById("scrollTopButton");
-    if (document.body.scrollTop > 200 || document.documentElement.scrollTop > 200) {
-      button.classList.add("show-btn");
-    } else {
-      button.classList.remove("show-btn");
-    }
-  }
+                if (window.scrollY > scrollThreshold) {
+                  // Remove 'd-none' to show the button and ensure it remains invisible on small screens
+                  scrollButton.classList.remove('d-none');
+                  scrollButton.classList.add('d-md-block');
+                } else {
+                  // Add 'd-none' to hide the button and 'd-md-block' is only effective on medium screens and up
+                  scrollButton.classList.add('d-none');
+                  scrollButton.classList.remove('d-md-block');
+                }
+              }
+
+              // Call the function on page load and on scroll
+              window.addEventListener('load', toggleScrollButton);
+              window.addEventListener('scroll', toggleScrollButton);
 
   // Scroll to the top when button is clicked
   document.getElementById("scrollTopButton").onclick = function() {


### PR DESCRIPTION
What does this PR do?
This PR introduces a reusable JavaScript plugin for a scroll-to-top button that appears when the user scrolls down a certain threshold on the page. This improves navigation and user experience by allowing quick access back to the top of the page with a single click. The button is initially hidden and only appears after the user has scrolled down 200 pixels from the top of the document. This feature has been implemented across all pages by including it in a common EJS partial.

Fixes #527 
Video
[Screencast from 2024-11-10 14-49-04.webm](https://github.com/user-attachments/assets/207870bf-0a0f-4241-9191-e04152ca1418)


Type of change
Bug fix (non-breaking change which fixes an issue)
How should this be tested?
To ensure the scroll-to-top button functions correctly, the following steps should be taken:

Scroll down on any page to see if the button appears after approximately 200 pixels.
Click the button to ensure it returns the page to the top smoothly.
Verify the button is hidden when the page is loaded and reappears upon scrolling down again.